### PR TITLE
PR/server configuration

### DIFF
--- a/instrumentserver/config/serverConfig.yml
+++ b/instrumentserver/config/serverConfig.yml
@@ -1,0 +1,7 @@
+instruments:
+  artys7:
+    type: qcodes_driver.ArtyS7.ArtyS7.ArtyS7
+    initialize: true
+    init:
+      serial_port: "/dev/ttyUSB1"
+      sequencer_repo: "/home/server/Desktop/Codes/ent/quail/user_fpga"


### PR DESCRIPTION
User can now register devices to the server GUI without having to open a client through the configuration file. When opening instrumentserver, use the flag -c with the path to the configuration file.